### PR TITLE
[22012143 김지안] 지출 추가 및 게임화 시스템 구현, JSON 파일에서 지출 불러오기 기능 추가

### DIFF
--- a/OSS_Budget/budget.py
+++ b/OSS_Budget/budget.py
@@ -24,4 +24,106 @@ class Budget:
         total = sum(e.amount for e in self.expenses)
         print(f"총 지출: {total}원\n")
 
+    def check_badges(self):
+        badges = []
 
+        total = sum(e.amount for e in self.expenses)
+        if total == 0:
+            return ["❌ 무소비 챌린저"]
+
+        # 1. 투자 귀신
+        if sum(1 for e in self.expenses if e.category == "투자") >= 5:
+            badges.append("💎 투자 귀신")
+
+        # 2. 먹보
+        food_total = sum(e.amount for e in self.expenses if e.category == "식비")
+        if food_total / total >= 0.3:
+            badges.append("🍔 먹보")
+
+        # 3. ALL IN
+        if any(e.amount >= 500000 for e in self.expenses):
+            badges.append("🔥 ALL IN")
+
+        # 4. 소확행러
+        small_cat = {"문화", "쇼핑", "기타"}
+        if sum(1 for e in self.expenses if e.category in small_cat) >= 5:
+            badges.append("🍰 소확행러")
+
+        # 5. 절약왕
+        if all(e.category != "현금" for e in self.expenses):
+            badges.append("🥇 절약왕")
+
+        # 6. 카드값 지옥
+        if total >= 2000000:
+            badges.append("💳 카드값 지옥")
+
+        # 7. 고정지출 러버
+        if sum(1 for e in self.expenses if e.category in {"예금", "적금"}) >= 2:
+            badges.append("🧾 고정지출 러버")
+
+        # 8. 한우먹은날
+        if any(e.amount >= 50000 and e.category == "식비" for e in self.expenses):
+            badges.append("🥩 한우먹은날")
+
+        return badges
+    
+    def get_level(self):
+        badges = self.check_badges()
+        return len(badges) // 5 + 1
+
+    def get_category_ratio_text(self):
+        from collections import defaultdict
+
+        category_totals = defaultdict(int)
+        for expense in self.expenses:
+            category_totals[expense.category] += expense.amount
+
+        total = sum(category_totals.values())
+        if total == 0:
+            return "지출 내역이 없습니다."
+
+        result = "[카테고리별 지출 비율]"
+        for category, amount in sorted(category_totals.items(), key=lambda x: -x[1]):
+            ratio = amount / total
+            bar = "█" * int(ratio * 20)
+            percent = round(ratio * 100)
+            result += f"\n{category.ljust(10)}: {bar.ljust(20)} {percent}%"
+        return result
+
+
+
+    def get_character_art(self, level):
+        if level == 1:
+            return r"""
+         (•‿•)
+        /(   )\
+         ^^ ^^
+            """
+        elif level == 2:
+            return r"""
+        \(•̀ᴗ•́)/
+         (   )
+        /|   |\
+            """
+        elif level == 3:
+            return r"""
+        ＼(°▽°)／
+         <(   )>
+          /| |\ 
+            """
+        elif level == 4:
+            return r"""
+         (ง •̀_•́)ง 
+         /     \
+        /|     |\
+            """
+        elif level >= 5:
+            return r"""
+        🏆(★‿★)🏆
+           /█\ /█\
+           / \ / \
+            """
+        else:
+            return r"""
+        (•_•)
+            """

--- a/OSS_Budget/example_budget.json
+++ b/OSS_Budget/example_budget.json
@@ -1,0 +1,302 @@
+[
+  {
+    "date": "2025-06-01",
+    "category": "식비",
+    "description": "편의점 도시락",
+    "amount": 5500
+  },
+  {
+    "date": "2025-06-02",
+    "category": "교통",
+    "description": "버스 요금",
+    "amount": 1200
+  },
+  {
+    "date": "2025-06-03",
+    "category": "예금",
+    "description": "월급 입금",
+    "amount": 2500000
+  },
+  {
+    "date": "2025-06-04",
+    "category": "적금",
+    "description": "청년 희망 적금",
+    "amount": 500000
+  },
+  {
+    "date": "2025-06-05",
+    "category": "투자",
+    "description": "국내 주식 매수",
+    "amount": 300000
+  },
+  {
+    "date": "2025-06-06",
+    "category": "투자",
+    "description": "해외 주식 매수",
+    "amount": 400000
+  },
+  {
+    "date": "2025-06-07",
+    "category": "투자",
+    "description": "채권 매수",
+    "amount": 150000
+  },
+  {
+    "date": "2025-06-08",
+    "category": "투자",
+    "description": "금 현물 매수",
+    "amount": 200000
+  },
+  {
+    "date": "2025-06-09",
+    "category": "투자",
+    "description": "달러 예치",
+    "amount": 100000
+  },
+  {
+    "date": "2025-06-10",
+    "category": "식비",
+    "description": "치킨 배달",
+    "amount": 18000
+  },
+  {
+    "date": "2025-06-11",
+    "category": "현금",
+    "description": "ATM 출금",
+    "amount": 300000
+  },
+  {
+    "date": "2025-06-12",
+    "category": "문화",
+    "description": "영화 관람",
+    "amount": 12000
+  },
+  {
+    "date": "2025-06-13",
+    "category": "쇼핑",
+    "description": "옷 구매",
+    "amount": 70000
+  },
+  {
+    "date": "2025-06-14",
+    "category": "현금",
+    "description": "현금 사용 (식당)",
+    "amount": 25000
+  },
+  {
+    "date": "2025-06-15",
+    "category": "교통",
+    "description": "지하철 정기권",
+    "amount": 55000
+  },
+  {
+    "date": "2025-06-16",
+    "category": "식비",
+    "description": "카페 아메리카노",
+    "amount": 4800
+  },
+  {
+    "date": "2025-06-17",
+    "category": "의료",
+    "description": "약국 지출",
+    "amount": 8200
+  },
+  {
+    "date": "2025-06-18",
+    "category": "기타",
+    "description": "택배비",
+    "amount": 3500
+  },
+  {
+    "date": "2025-06-19",
+    "category": "현금",
+    "description": "친구 생일 선물",
+    "amount": 40000
+  },
+  {
+    "date": "2025-06-20",
+    "category": "투자",
+    "description": "암호화폐 매수",
+    "amount": 50000
+  },
+  {
+    "date": "2025-06-21",
+    "category": "기타",
+    "description": "기타 소모품",
+    "amount": 194081
+  },
+  {
+    "date": "2025-06-22",
+    "category": "기타",
+    "description": "팁",
+    "amount": 234221
+  },
+  {
+    "date": "2025-06-23",
+    "category": "적금",
+    "description": "목표 저축",
+    "amount": 183323
+  },
+  {
+    "date": "2025-06-24",
+    "category": "현금",
+    "description": "현금 사용",
+    "amount": 176372
+  },
+  {
+    "date": "2025-06-25",
+    "category": "현금",
+    "description": "현금 인출",
+    "amount": 172996
+  },
+  {
+    "date": "2025-06-26",
+    "category": "교통",
+    "description": "지하철",
+    "amount": 280040
+  },
+  {
+    "date": "2025-06-27",
+    "category": "예금",
+    "description": "보너스 입금",
+    "amount": 256617
+  },
+  {
+    "date": "2025-06-28",
+    "category": "적금",
+    "description": "목표 저축",
+    "amount": 182782
+  },
+  {
+    "date": "2025-06-29",
+    "category": "식비",
+    "description": "배달 음식",
+    "amount": 8084
+  },
+  {
+    "date": "2025-06-30",
+    "category": "문화",
+    "description": "전시회",
+    "amount": 154572
+  },
+  {
+    "date": "2025-07-01",
+    "category": "예금",
+    "description": "보너스 입금",
+    "amount": 223200
+  },
+  {
+    "date": "2025-07-02",
+    "category": "쇼핑",
+    "description": "전자제품",
+    "amount": 266848
+  },
+  {
+    "date": "2025-07-03",
+    "category": "식비",
+    "description": "패스트푸드",
+    "amount": 234303
+  },
+  {
+    "date": "2025-07-04",
+    "category": "문화",
+    "description": "전시회",
+    "amount": 200195
+  },
+  {
+    "date": "2025-07-05",
+    "category": "쇼핑",
+    "description": "전자제품",
+    "amount": 235581
+  },
+  {
+    "date": "2025-07-06",
+    "category": "식비",
+    "description": "분식",
+    "amount": 76493
+  },
+  {
+    "date": "2025-07-07",
+    "category": "예금",
+    "description": "기타 예금",
+    "amount": 243231
+  },
+  {
+    "date": "2025-07-08",
+    "category": "식비",
+    "description": "분식",
+    "amount": 286648
+  },
+  {
+    "date": "2025-07-09",
+    "category": "기타",
+    "description": "기부",
+    "amount": 14061
+  },
+  {
+    "date": "2025-07-10",
+    "category": "현금",
+    "description": "현금 인출",
+    "amount": 179101
+  },
+  {
+    "date": "2025-07-11",
+    "category": "쇼핑",
+    "description": "화장품",
+    "amount": 119386
+  },
+  {
+    "date": "2025-07-12",
+    "category": "의료",
+    "description": "건강검진",
+    "amount": 42513
+  },
+  {
+    "date": "2025-07-13",
+    "category": "쇼핑",
+    "description": "화장품",
+    "amount": 58237
+  },
+  {
+    "date": "2025-07-14",
+    "category": "현금",
+    "description": "현금 인출",
+    "amount": 76645
+  },
+  {
+    "date": "2025-07-15",
+    "category": "식비",
+    "description": "분식",
+    "amount": 6698
+  },
+  {
+    "date": "2025-07-16",
+    "category": "현금",
+    "description": "현금 사용",
+    "amount": 61095
+  },
+  {
+    "date": "2025-07-17",
+    "category": "기타",
+    "description": "팁",
+    "amount": 119513
+  },
+  {
+    "date": "2025-07-18",
+    "category": "문화",
+    "description": "책 구입",
+    "amount": 244063
+  },
+  {
+    "date": "2025-07-19",
+    "category": "교통",
+    "description": "버스",
+    "amount": 170967
+  },
+  {
+    "date": "2025-07-20",
+    "category": "현금",
+    "description": "현금 인출",
+    "amount": 77993
+  }
+]

--- a/OSS_Budget/json_loader.py
+++ b/OSS_Budget/json_loader.py
@@ -1,0 +1,25 @@
+import json
+from expense import Expense
+
+def load_expenses_from_json(file_path):
+    expenses = []
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        for item in data:
+            if all(k in item for k in ("date", "category", "description", "amount")):
+                expense = Expense(
+                    date=item["date"],
+                    category=item["category"],
+                    description=item["description"],
+                    amount=item["amount"]
+                )
+                expenses.append(expense)
+            else:
+                print(f"[무시됨] 잘못된 항목: {item}")
+
+    except Exception as e:
+        print(f"[오류] JSON 불러오기 실패: {e}")
+
+    return expenses

--- a/OSS_Budget/main.py
+++ b/OSS_Budget/main.py
@@ -1,40 +1,90 @@
 from budget import Budget
-
+from json_loader import load_expenses_from_json
 
 def main():
     budget = Budget()
 
     while True:
-        print("==== 간단 가계부 ====")
-        print("1. 지출 추가")
-        print("2. 지출 목록 보기")
-        print("3. 총 지출 보기")
-        print("4. 종료")
+        display_main_menu()
         choice = input("선택 > ")
 
         if choice == "1":
-            category = input("카테고리 (예: 식비, 교통 등): ")
-            description = input("설명: ")
-            try:
-                amount = int(input("금액(원): "))
-            except ValueError:
-                print("잘못된 금액입니다.\n")
-                continue
-            budget.add_expense(category, description, amount)
-
+            handle_add_expense(budget)
         elif choice == "2":
             budget.list_expenses()
-
         elif choice == "3":
             budget.total_spent()
-
         elif choice == "4":
+            display_badges(budget)
+        elif choice == "5":
             print("가계부를 종료합니다.")
             break
-
         else:
             print("잘못된 선택입니다.\n")
 
+
+def display_main_menu():
+    print("==== 간단 가계부 ====")
+    print("1. 지출 추가")
+    print("2. 지출 목록 보기")
+    print("3. 총 지출 보기")
+    print("4. 배지 보기")
+    print("5. 종료")
+
+
+def handle_add_expense(budget):
+    print("1. 직접 입력")
+    print("2. JSON 파일에서 불러오기")
+    sub_choice = input("선택 > ")
+
+    if sub_choice == "1":
+        add_expense_manually(budget)
+    elif sub_choice == "2":
+        add_expense_from_json(budget)
+        # OSS_Budget\example_budget.json
+    else:
+        print("잘못된 선택입니다.\n")
+
+
+def add_expense_manually(budget):
+    category = input("카테고리 (예: 식비, 교통 등): ")
+    description = input("설명: ")
+    try:
+        amount = int(input("금액(원): "))
+    except ValueError:
+        print("잘못된 금액입니다.\n")
+        return
+    budget.add_expense(category, description, amount)
+
+
+def add_expense_from_json(budget):
+    path = input("불러올 JSON 파일 경로 입력 > ").strip('"')
+    from json_loader import load_expenses_from_json
+    new_expenses = load_expenses_from_json(path)
+    for e in new_expenses:
+        budget.expenses.append(e)
+    print(f"{len(new_expenses)}개의 지출 내역이 추가되었습니다.\n")
+
+
+def display_badges(budget):
+    print("\n(・ω・)ノ  당신의 소비 모험 결과!")
+    print("=====================================")
+
+    budget.check_badges()
+    level = budget.get_level()
+    print("✨ 당신의 캐릭터")
+    art = budget.get_character_art(level)
+    print(art)
+
+    badges = budget.check_badges()
+    print(f"🎖 현재 레벨: Lv.{level}")
+    print(f"🏅 보유한 배지 수: {len(badges)}개")
+    print("📌 보유 배지 목록:")
+    for b in badges:
+        print(f" - {b}")
+    print("")
+    print(budget.get_category_ratio_text())
+    print("=====================================\n")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## 요약

중복 카테고리 없이 지출 비율을 깔끔하게 보여줄 수 있도록 `budget.py`의 카테고리 비율 표시 로직을 리팩터링했습니다.

## 변경 사항

- `get_category_ratio_text()` 함수 수정:
  - 각 카테고리별 지출을 딕셔너리로 집계
  - 지출 금액 기준으로 카테고리를 내림차순 정렬
  - 중복 없이 각 카테고리를 한 번만 출력하며, 텍스트 그래프와 비율 표시 추가

## 변경 이유

이전에는 같은 카테고리가 여러 번 반복 출력되어 시각적으로 혼란을 주고, 분석이 어려웠습니다. 이번 변경으로 각 카테고리는 한 번만 표시되어 전체 요약이 명확해졌습니다.

## 변경 파일

- `budget.py`

## 테스트

- `example_budget.json` 파일로 직접 실행하여 카테고리별 비율 출력이 정상적으로 표시되는지 확인 완료

## 출력 결과

(・ω・)ノ  당신의 소비 모험 결과!
=====================================
✨ 당신의 캐릭터

        \(•̀ᴗ•́)/
         (   )
        /|   |\

🎖 현재 레벨: Lv.2
🏅 보유한 배지 수: 6개
📌 보유 배지 목록:
 - 💎 투자 귀신
 - 🔥 ALL IN
 - 🍰 소확행러
 - 💳 카드값 지옥
 - 🧾 고정지출 러버
 - 🥩 한우먹은날

[카테고리별 지출 비율]
예금        : ██████               34%
투자        : ██                   13%
현금        : ██                   12%
적금        : █                    9%
쇼핑        : █                    8%
식비        : █                    7%
문화        : █                    6%
기타        : █                    6%
교통        : █                    5%
의료        :                      1%
=====================================