### PR TITLE
[22012112 이새진] 1000원 단위 구분자 적용 + 카테고리별 총액 pie chart를 통한 시각화

### DIFF
--- a/OSS_Budget/budget.py
+++ b/OSS_Budget/budget.py
@@ -1,14 +1,25 @@
 import datetime
 from expense import Expense
+import matplotlib.pyplot as plt
 
 class Budget:
     def __init__(self):
         self.expenses = []
+        self.cate = []
+        self.cate_total = []
 
     def add_expense(self, category, description, amount):
         today = datetime.date.today().isoformat()
         expense = Expense(today, category, description, amount)
         self.expenses.append(expense)
+
+        if category not in self.cate:
+            self.cate.append(category)
+            self.cate_total.append(0)
+        
+        idx = self.cate.index(category)
+        self.cate_total[idx] += amount
+
         print("지출이 추가되었습니다.\n")
 
     def list_expenses(self):
@@ -22,6 +33,19 @@ class Budget:
 
     def total_spent(self):
         total = sum(e.amount for e in self.expenses)
-        print(f"총 지출: {total}원\n")
+        print(f"총 지출: {total:,}원\n")  
 
+    def show_graph(self, path=None):
+        fig = plt.figure(num="간단 가계부")
+        wedgeprops={'width': 0.7, 'edgecolor': 'w', 'linewidth': 3}
+        legend_labels = [f"{total:,}원" for total in self.cate_total]
+        labels =[f"{cat}" for cat in self.cate]
+        today = datetime.datetime.now()
 
+        plt.rcParams['font.family'] ='Malgun Gothic'
+        plt.rcParams['axes.unicode_minus'] = False
+        plt.title(today.strftime("<%Y년 %m월 가계부 카테고리별 지출 총액>"))
+        plt.pie(self.cate_total, labels=labels, autopct='%.2f%%', wedgeprops=wedgeprops)
+        plt.legend(legend_labels, title='카테고리별 지출 총액', fontsize=8, bbox_to_anchor=(0.9, 1.0))
+
+        plt.show()

--- a/OSS_Budget/expense.py
+++ b/OSS_Budget/expense.py
@@ -1,4 +1,3 @@
-
 class Expense:
     def __init__(self, date, category, description, amount):
         self.date = date
@@ -7,4 +6,4 @@ class Expense:
         self.amount = amount
 
     def __str__(self):
-        return f"[{self.date}] {self.category} - {self.description}: {self.amount}원"
+        return f"[{self.date}] {self.category} - {self.description}: {self.amount:,}원"

--- a/OSS_Budget/main.py
+++ b/OSS_Budget/main.py
@@ -1,6 +1,5 @@
 from budget import Budget
 
-
 def main():
     budget = Budget()
 
@@ -9,7 +8,8 @@ def main():
         print("1. 지출 추가")
         print("2. 지출 목록 보기")
         print("3. 총 지출 보기")
-        print("4. 종료")
+        print("4. 카테고리별 지출 총액 보기")
+        print("5. 종료")
         choice = input("선택 > ")
 
         if choice == "1":
@@ -17,6 +17,9 @@ def main():
             description = input("설명: ")
             try:
                 amount = int(input("금액(원): "))
+                if (amount <= 0):
+                    print("음수 혹은 0원은 입력할 수 없습니다.\n")
+                    continue
             except ValueError:
                 print("잘못된 금액입니다.\n")
                 continue
@@ -29,12 +32,17 @@ def main():
             budget.total_spent()
 
         elif choice == "4":
+            if not budget.expenses:
+                print("가계부가 비어있어 차트를 생성할 수 없습니다.\n")
+                continue
+            budget.show_graph()
+
+        elif choice == "5":
             print("가계부를 종료합니다.")
             break
 
         else:
             print("잘못된 선택입니다.\n")
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## 추가된 기능
* 카테고리별 총액 pie chart 시각화
  * 가계부가 비어있을 시, 시각화 X
* 지출 차지율, 총액 표기

## 수정 사항
* 1000원 단위 구분자 적용
* 음수 단위 혹은 0원 입력 오류 처리

## 변경 사항
* main.py
  * choice 항목 추가
  * 음수 단위, 0원 입력 오류 처리
* budget.py
  * add_expense()
    * 카테고리와 각 카테고리 누계 변수
    * 카테고리 중복 처리
  * show_graph()
    * matplotlib를 활용하여 차트 구현
* budget.py, expense.py
  * 1000원 단위 금액 표기

## 출력 결과
```
1. 음수 혹은 0원 처리

==== 간단 가계부 ====
1. 지출 추가
3. 지출 목록 보기
4. 총 지출 보기
5. 카테고리별 지출 총액 보기
6. 종료
선택 > 1
카테고리 (예: 식비, 교통 등): 식비
설명: 배달
금액(원): 0
음수 혹은 0원은 입력할 수 없습니다.

==== 간단 가계부 ====
1. 지출 추가
2. 지출 목록 보기
3. 총 지출 보기
4. 카테고리별 지출 총액 보기
5. 종료
선택 > 1
카테고리 (예: 식비, 교통 등): 식비
설명: 배달
금액(원): -1
음수 혹은 0원은 입력할 수 없습니다.

2. 비어있는 경우 처리

==== 간단 가계부 ====
1. 지출 추가
2. 지출 목록 보기
4. 총 지출 보기
5. 카테고리별 지출 총액 보기
6. 종료
선택 > 4
가계부가 비어있어 차트를 생성할 수 없습니다.
```

<p align="center"><img src="https://github.com/user-attachments/assets/d3a7d94d-d22f-4b8d-829a-c3ca260208bf" height="400px" width="500px"></p>
<p align="center">[그림 1] - 지출 내역을 바탕으로 각 카테고리별 pie chart 생성</p>
